### PR TITLE
Trac 10694 Italics are not displaying in search results

### DIFF
--- a/includes/elasticpress.php
+++ b/includes/elasticpress.php
@@ -14,10 +14,126 @@
  * @return array
  */
 function mla_style_custom_ep_search_results_array( $results, $response ) {
-    foreach($results[posts] as &$post ) {
-        $post[post_content] = apply_filters('the_content', get_post_field('post_content', $post[post_id]));
-        $post[post_title] = apply_filters('the_title', get_post_field('post_title', $post[post_id])); 
+    global $wpdb, $table_prefix;
+
+    foreach($results['posts'] as &$post ) {
+	$post_content =  get_post_field('post_content', $post['post_id']);
+
+	if(stristr( $post_content, "WpProQuiz") !== false ) {
+            preg_match('/WpProQuiz\s*(\d+)/', $post_content, $matches);
+
+            $quiz = $wpdb->get_var($wpdb->prepare("SELECT text FROM ". $table_prefix ."wp_pro_quiz_master WHERE id = %d LIMIT 1", $matches[1]));
+
+            $post['post_content'] = $quiz;
+            $post['post_excerpt'] = $quiz;
+
+        } else {
+
+            $post['post_content'] = apply_filters('the_content', get_post_field('post_content', $post['post_id']));
+            $post['post_title'] = apply_filters('the_title', get_post_field('post_title', $post['post_id']));
+	        $post['post_excerpt'] = apply_filters('the_excerpt', get_post_field('post_excerpt', $post['post_id']));
+        }
     }
+
     return $results;
 }
 add_filter('ep_search_results_array', 'mla_style_custom_ep_search_results_array', 10, 2);
+
+/**
+ * Fix html that may be malformed due to preg_match.
+ *
+ * @param string $src The html to fix.
+ */
+function mla_style_custom_html_tidy( $src ){
+    libxml_use_internal_errors(true);
+
+    $x = new DOMDocument;
+    $x->loadHTML('<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />'.$src);
+    $x->formatOutput = true;
+
+    $ret = preg_replace('~<(?:!DOCTYPE|/?(?:html|body|head))[^>]*>\s*~i', '', $x->saveHTML());
+
+    return trim(str_replace('<meta http-equiv="Content-Type" content="text/html;charset=utf-8">','',$ret));
+}
+
+/**
+ * Make sure open html tags are closed.
+ *
+ * @param string $html The html to fix.
+ */
+function mla_style_custom_close_tags( $html ) {
+    preg_match_all('#<(?!meta|img|br|hr|input\b)\b([a-z]+)(?: .*)?(?<![/|/ ])>#iU', $html, $result);
+
+    $openedtags = $result[1];
+    preg_match_all('#</([a-z]+)>#iU', $html, $result);
+
+    $closedtags = $result[1];
+    $len_opened = count($openedtags);
+
+    if (count($closedtags) == $len_opened) {
+        return $html;
+    }
+
+	$openedtags = array_reverse($openedtags);
+
+    for ($i=0; $i < $len_opened; $i++) {
+        if (!in_array($openedtags[$i], $closedtags)) {
+            $html .= '</'.$openedtags[$i].'>';
+        } else {
+            unset($closedtags[array_search($openedtags[$i], $closedtags)]);
+        }
+    }
+    return $html;
+}
+
+/**
+ * Allow html in excerpt.
+ *
+ * @param string $excerpt The excerpt.
+ */
+function mla_style_custom_wp_trim_excerpt( $excerpt ) {
+    $raw_excerpt = $excerpt;
+
+    if ( '' == $excerpt ) {
+
+        $excerpt = get_the_content('');
+        $excerpt = strip_shortcodes( $excerpt );
+        $excerpt = apply_filters('the_content', $excerpt);
+        $excerpt = str_replace(']]>', ']]&gt;', $excerpt);
+        $excerpt = strip_tags($excerpt, '<i><em>'); /*IF you need to allow just certain tags. Delete if all tags are allowed */
+
+        //Set the excerpt word count and only break after sentence is complete.
+        $excerpt_word_count = 100;
+        $excerpt_length = apply_filters('excerpt_length', $excerpt_word_count);
+        $tokens = array();
+        $excerpt_output = '';
+        $count = 0;
+
+        // Divide the string into tokens; HTML tags, or words, followed by any whitespace
+        preg_match_all('/(<[^>]+>|[^<>\s]+)\s*/u', $excerpt, $tokens);
+
+        foreach ($tokens[0] as $token) {
+
+            if ($count >= $excerpt_length && preg_match('/[\,\;\?\.\!]\s*$/uS', $token)) {
+            // Limit reached, continue until , ; ? . or ! occur at the end
+                $excerpt_output .= trim($token);
+                break;
+            }
+
+            // Add words to complete sentence
+            $count++;
+
+            // Append what's left of the token
+            $excerpt_output .= $token;
+        }
+
+    $excerpt = trim( force_balance_tags( $excerpt_output ) );
+
+    return $excerpt;
+
+    }
+    return apply_filters('mla_style_custom_wp_trim_excerpt', $excerpt, $raw_excerpt);
+}
+
+remove_filter('get_the_excerpt', 'wp_trim_excerpt');
+add_filter('get_the_excerpt', 'mla_style_custom_wp_trim_excerpt');


### PR DESCRIPTION
Adding filter to allow html in excerpts, adding a routine to get the only the descrption of the quiz to be used in excerpts, Adding functions to automatically close unopened tags and fix malformed tags caused by preg_match.

See https://trac.mla.org/traffic/ticket/10694